### PR TITLE
chore: migrate Renovate config syntax

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
-  "extends": ["config:base"],
-  "regexManagers": [
+  "extends": ["config:recommended"],
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["^shellhub/Makefile$"],
       "matchStrings": [
         "DISTVERSION=\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
@@ -13,13 +14,13 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "enabled": false
     },
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "shellhub-io/shellhub"
       ],
       "enabled": true


### PR DESCRIPTION
## Summary
- migrate Renovate from `config:base` to `config:recommended`
- move the regex manager to `customManagers` with `customType: "regex"`
- replace deprecated `matchPackagePatterns` with `matchPackageNames`

## Why
Dependency Dashboard #16 reports "Config Migration Needed". This keeps the existing ShellHub tag tracking behavior while using current Renovate config keys.

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

No credentials, registry settings, publishing, or admin changes are involved.